### PR TITLE
feat: タイトルと複数の単語を入力出来るように

### DIFF
--- a/pages/api/generate.ts
+++ b/pages/api/generate.ts
@@ -6,20 +6,39 @@ const configuration = new Configuration({
 })
 const openai = new OpenAIApi(configuration)
 
+// export default async function (req: NextApiRequest, res: NextApiResponse) {
+//   const completion = await openai.createCompletion({
+//     model: 'text-davinci-003',
+//     prompt: generatePrompt(req.body.animal),
+//     temperature: 0.6,
+//     max_tokens: 1000,
+//   })
+//   res.status(200).json({ result: completion.data.choices[0].text })
+// }
+// const generatePrompt = (animal) => {
+//   const capitalizedAnimal =
+//     animal[0].toUpperCase() + animal.slice(1).toLowerCase()
+//   return `今からあなたは小説を書きます。タイトルは「初登校」です。「学校」、「先生」の単語使って、会話の多い小説を作成して下さい`
+// }
+
 export default async function (req: NextApiRequest, res: NextApiResponse) {
   const completion = await openai.createCompletion({
     model: 'text-davinci-003',
-    prompt: generatePrompt(req.body.animal),
+    prompt: generatePrompt(req.body.title, req.body.words),
     temperature: 0.6,
     max_tokens: 1000,
   })
   res.status(200).json({ result: completion.data.choices[0].text })
-  // res.status(200).json({ result: completion.data.choices })
 }
 
-function generatePrompt(animal) {
-  const capitalizedAnimal =
-    animal[0].toUpperCase() + animal.slice(1).toLowerCase()
+const generatePrompt = (title: string, words: string[]) => {
+  let wordModified = ''
+  // for (const word of words) {
+  //   wordModified += `「${word}」、`
+  // }
+  for (let i = 0; i < words.length; i++) {
+    wordModified += `「${words[i]}」、`
+  }
   //   return `Suggest three names for an animal that is a superhero.
 
   // Animal: Cat
@@ -28,6 +47,10 @@ function generatePrompt(animal) {
   // Names: Ruff the Protector, Wonder Canine, Sir Barks-a-Lot
   // Animal: ${capitalizedAnimal}
   // Names:`
-  return `今からあなたは小説を書きます。タイトルは「初登校」です。「学校」、「先生」の単語使って完成させてください。`
+  // return `今からあなたは小説を書きます。タイトルは「初登校」です。「学校」、「先生」の単語使って完成させてください`
   // return `私はごはんが大好きですが、もっと美味しく食べるにはどうすれば良いですか？`
+  // return `今からあなたは小説を書きます。タイトルは「初登校」です。「学校」、「先生」の単語使って、頭のいかれた小説を完成させてください`
+  // return `今からあなたは小説を書きます。タイトルは「初登校」です。「学校」、「先生」の単語使って、続きが気になる非常に面白い小説を作成して下さい`
+  // return `今からあなたは小説を書きます。タイトルは「初登校」です。「学校」、「先生」の単語使って、会話の多い小説を作成して下さい`
+  return `今からあなたは小説を書きます。タイトルは「${title}」です。${wordModified}の単語使って、続きが気になる非常に面白く、会話の多い小説を作成して下さい`
 }

--- a/pages/index.module.css
+++ b/pages/index.module.css
@@ -1,15 +1,15 @@
 @font-face {
-  font-family: "ColfaxAI";
+  font-family: 'ColfaxAI';
   src: url(https://cdn.openai.com/API/fonts/ColfaxAIRegular.woff2)
-      format("woff2"),
-    url(https://cdn.openai.com/API/fonts/ColfaxAIRegular.woff) format("woff");
+      format('woff2'),
+    url(https://cdn.openai.com/API/fonts/ColfaxAIRegular.woff) format('woff');
   font-weight: normal;
   font-style: normal;
 }
 @font-face {
-  font-family: "ColfaxAI";
-  src: url(https://cdn.openai.com/API/fonts/ColfaxAIBold.woff2) format("woff2"),
-    url(https://cdn.openai.com/API/fonts/ColfaxAIBold.woff) format("woff");
+  font-family: 'ColfaxAI';
+  src: url(https://cdn.openai.com/API/fonts/ColfaxAIBold.woff2) format('woff2'),
+    url(https://cdn.openai.com/API/fonts/ColfaxAIBold.woff) format('woff');
   font-weight: bold;
   font-style: normal;
 }
@@ -18,7 +18,7 @@
   font-size: 16px;
   line-height: 24px;
   color: #353740;
-  font-family: "ColfaxAI", Helvetica, sans-serif;
+  font-family: 'ColfaxAI', Helvetica, sans-serif;
 }
 .main {
   display: flex;
@@ -41,7 +41,7 @@
   flex-direction: column;
   width: 320px;
 }
-.main input[type="text"] {
+.main input[type='text'] {
   padding: 12px 16px;
   border: 1px solid #10a37f;
   border-radius: 4px;
@@ -51,8 +51,17 @@
   color: #8e8ea0;
   opacity: 1;
 }
-.main input[type="submit"] {
+.main input[type='submit'] {
   padding: 12px 0;
+  color: #fff;
+  background-color: #10a37f;
+  border: none;
+  border-radius: 4px;
+  text-align: center;
+  cursor: pointer;
+}
+.main button {
+  padding: 12px 6px;
   color: #fff;
   background-color: #10a37f;
   border: none;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -4,7 +4,9 @@ import styles from './index.module.css'
 import Image from 'next/image'
 
 export default function Home() {
-  const [animalInput, setAnimalInput] = useState('')
+  const [title, setTitle] = useState('')
+  const [wordList, setWordList] = useState<string[]>([])
+  const [word, setWord] = useState<string>('')
   const [result, setResult] = useState()
 
   async function onSubmit(event) {
@@ -14,12 +16,11 @@ export default function Home() {
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ animal: animalInput }),
+      body: JSON.stringify({ title, words: wordList }),
     })
     const data = await response.json()
     console.log(data)
     setResult(data.result)
-    setAnimalInput('')
   }
 
   return (
@@ -38,16 +39,47 @@ export default function Home() {
           alt=''
         />
         <h3>Name my pet</h3>
+
         <form onSubmit={onSubmit}>
+          <p>タイトル</p>
           <input
             type='text'
-            name='animal'
-            placeholder='Enter an animal'
-            value={animalInput}
-            onChange={e => setAnimalInput(e.target.value)}
+            name='title'
+            placeholder='Enter an title'
+            value={title}
+            onChange={e => setTitle(e.target.value)}
           />
+          <p>単語</p>
+          <input
+            type='text'
+            name='word'
+            placeholder='Enter an word'
+            value={word}
+            onChange={e => setWord(e.target.value)}
+          />
+          <button
+            type='button'
+            onClick={() => {
+              setWord('')
+              setWordList([...wordList, word])
+            }}
+          >
+            Add +
+          </button>
+          {wordList.map((word, i) => (
+            <p
+              key={i}
+              onClick={() => {
+                setWordList(wordList.filter((_, index) => index !== i))
+              }}
+            >
+              {word}
+            </p>
+          ))}
+
           <input type='submit' value='Generate names' />
         </form>
+
         <div className={styles.result}>{result}</div>
       </main>
     </div>


### PR DESCRIPTION
## 詳細
- title, wordsをapiにbodyで渡す。
- wordsはフロントで、TODOリストみたいに追加出来る
- レスポンスの文字数を16文字から、1000文字まで拡張


## 動作確認
![image](https://user-images.githubusercontent.com/88410576/209419085-defa266a-ef6a-4230-b93a-19c32e87847d.png)
