### PR TITLE
fix: 続きのモデルを一つ下げる、一貫性のオプションを無くす

### DIFF
--- a/src/components/NovelForm.tsx
+++ b/src/components/NovelForm.tsx
@@ -20,7 +20,6 @@ export const NovelForm: FC<Props> = ({ setNovel, onScrollToBottom }) => {
   const [title, setTitle] = useInputState('')
   const [word, setWord] = useInputState('')
   const [wordList, setWordList] = useState<string[]>([])
-  const [hasConsistency, setHasConsistency] = useState(true) // 話の一貫性
   const [isLoading, setIsLoading] = useState(false)
 
   // 小説を生成
@@ -38,7 +37,7 @@ export const NovelForm: FC<Props> = ({ setNovel, onScrollToBottom }) => {
       })
 
       const data = await response.json()
-      setNovel({ title, hasConsistency, body: [data.result] })
+      setNovel({ title, body: [data.result] })
       onScrollToBottom()
 
       setTitle('')
@@ -97,24 +96,6 @@ export const NovelForm: FC<Props> = ({ setNovel, onScrollToBottom }) => {
           >
             追加 +
           </Button>
-        </Stack>
-
-        <Stack spacing='xs'>
-          <label className='font-weight-500 text-sm'>小説の展開</label>
-          <Flex gap='xl'>
-            <Radio
-              label='おだやか'
-              checked={hasConsistency}
-              onChange={() => setHasConsistency(true)}
-              color='indigo'
-            />
-            <Radio
-              label='はげしい'
-              checked={!hasConsistency}
-              onChange={() => setHasConsistency(false)}
-              color='indigo'
-            />
-          </Flex>
         </Stack>
 
         <Space />

--- a/src/pages/api/generate.ts
+++ b/src/pages/api/generate.ts
@@ -4,6 +4,8 @@ import { openai } from '../../libs/openai'
 export default async function (req: NextApiRequest, res: NextApiResponse) {
   const completion = await openai.createCompletion({
     model: 'text-davinci-003',
+    // model: 'text-curie-001',
+    // model: 'text-babbage-001',
     prompt: generatePrompt(req.body.title, req.body.words),
     temperature: 0.6,
     max_tokens: 300,

--- a/src/pages/api/generate_for_more.ts
+++ b/src/pages/api/generate_for_more.ts
@@ -4,7 +4,9 @@ import { openai } from '../../libs/openai'
 export default async function (req: NextApiRequest, res: NextApiResponse) {
   const { previousNovel, futureStory, title } = req.body
   const completion = await openai.createCompletion({
-    model: 'text-davinci-003',
+    // model: 'text-davinci-003',
+    model: 'text-curie-001',
+    // model: 'text-babbage-001',
     prompt: generatePrompt(title, previousNovel, futureStory),
     temperature: 0.6,
     max_tokens: 300,

--- a/src/pages/api/test.ts
+++ b/src/pages/api/test.ts
@@ -4,7 +4,7 @@ import { openai } from '../../libs/openai'
 export default async function (req: NextApiRequest, res: NextApiResponse) {
   const completion = await openai.createCompletion({
     model: 'text-davinci-003',
-    prompt: `今からあなたは小説を書きます。タイトルは「ファイアウォールとファミリーマート」です。 の単語使って作成して下さい。続きが気になり非常に面白く、会話の多い小説にして下さい。`,
+    prompt: `ファンタジーな小説を書いてください`,
     temperature: 0.6,
     max_tokens: 100,
   })

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -38,10 +38,7 @@ export default function Home() {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
-          // 一貫性があるか、展開が変わりやすいか
-          previousNovel: novel.hasConsistency
-            ? novel.body.join('\n\n').slice(-900) // リクエストは1000文字が限度
-            : novel.body[novel.body.length - 1],
+          previousNovel: novel.body[novel.body.length - 1],
           futureStory,
           title: novel.title,
         }),


### PR DESCRIPTION
##  詳細
openaiのリクエストのtokenが多すぎるので、対策をする
- 続きを読むのモデルをtext-currie-001に下げる
- 小説の一貫性を無くす(今まで最大900tokenが発生してた)
- これにより、一度のリクエストの最大tokenが 100だとすると、3になる。(davinci * 900 == currie * 10 * 900)

## 動作確認
一回目 text-davinci-003
二回目 text-currie-001
![スクリーンショット_20221228_080556](https://user-images.githubusercontent.com/88410576/209735242-6d999b49-6d78-4bb8-9436-d94920c795eb.png)


モデル: text-currie-001
![スクリーンショット_20221228_075657](https://user-images.githubusercontent.com/88410576/209735203-3bd730e0-514b-4f30-b2cf-7f5031eca8b0.png)

モデル: text-babbage-001
![スクリーンショット_20221228_075637](https://user-images.githubusercontent.com/88410576/209735186-304ef3e6-a3d1-457b-89fe-d6034985bc23.png)

